### PR TITLE
Update REQUEST-914-FILE-DETECTION.conf

### DIFF
--- a/rules/REQUEST-914-FILE-DETECTION.conf
+++ b/rules/REQUEST-914-FILE-DETECTION.conf
@@ -12,7 +12,6 @@
 #
 
 
-SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:1,id:914011,nolog,pass,tag:'paranoia-level/1',skipAfter:END-REQUEST-914-FILE-DETECTION"
 SecRule TX:PARANOIA_LEVEL "@lt 1" "phase:2,id:914012,nolog,pass,tag:'paranoia-level/1',skipAfter:END-REQUEST-914-FILE-DETECTION"
 #
 # -= Paranoia Level 1 (default) =- (apply only when tx.paranoia_level is sufficiently high: 1 or higher)
@@ -65,7 +64,7 @@ SecMarker "BEGIN-REQUEST-914-FILE-UPLOAD-EXE"
 # all EXE and DLL verification rules only check the first three bytes up to the NOP and leave the NULL out of the regex
 SecRule ARGS|XML|XML:/* \
     "@rx ^(?:\x4d\x5a(?:\x90|\x50)|\x7f\x45\x4c\x46)" \
-    "id:914100,\
+    "id:914010,\
     phase:2,\
     block,\
     msg:'Possible harmful executable file detected',\
@@ -87,7 +86,7 @@ SecMarker "BEGIN-REQUEST-914-FILE-UPLOAD-STREAM"
 
 #STREAM variables are not compatible with libModSecurity (v3), commenting those rules that cause compatibility issues
 #SecRule MODSEC_BUILD "!@rx ^020" \
-#    "id:914110,\
+#    "id:914011,\
 #    phase:2,\
 #    pass,\
 #    noauditlog,\
@@ -113,7 +112,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:914014,nolog,pass,tag:'paranoia-le
 # Note : This directive is NOT supported for libModSecurity (v3).
 #SecStreamInBodyInspection On
 #SecRule STREAM_INPUT_BODY "@rx ^(?:\x4d\x5a(?:\x90|\x50)\x00|\x7f\x45\x4c\x46)" \
-#    "id:9142010,\
+#    "id:914021,\
 #    phase:2,\
 #    block,\
 #    msg:'Possible harmful file detected',\
@@ -134,7 +133,7 @@ SecRule TX:PARANOIA_LEVEL "@lt 2" "phase:2,id:914014,nolog,pass,tag:'paranoia-le
 # 9142020 does exactly the same as 914210 but uses REQUEST_BODY variable instead of STREAM_INPUT_BODY variable which
 # is the entire body and not just the part of the stream that is being received
 SecRule REQUEST_BODY "@rx ^(?:\x4d\x5a(?:\x90|\x50)|\x7f\x45\x4c\x46)" \
-    "id:9142020,\
+    "id:914022,\
     phase:2,\
     block,\
     msg:'Possible harmful executable file detected in request body',\
@@ -159,7 +158,7 @@ SecMarker "END-REQUEST-914-FILE-UPLOAD-STREAM"
 # Note : Starting in version 2.9 ModSecurity will not fill the FILES_TMPNAMES variable
 # unless SecTmpSaveUploadedFiles directive is On, or the SecUploadKeepFiles directive is set to RelevantOnly.
 SecRule FILES_TMP_CONTENT "@rx ^(?:\x4d\x5a(?:\x90|\x50)|\x7f\x45\x4c\x46)" \
-    "id:9142030,\
+    "id:914023,\
     phase:2,\
     block,\
     msg:'Possible harmful executable file detected in uploaded file',\
@@ -197,7 +196,7 @@ SecMarker "BEGIN-REQUEST-914-FILE-UPLOAD-IMAGE"
 
 # This rule checks if the uploaded file extension matches the file header type
 SecRule FILES_TMPNAMES "@rx (?:jpeg|jpg|gif|png|bmp|image|ico)$" \
-    "id:9142040,\
+    "id:914024,\
     phase:2,\
     block,\
     msg:'Declared Image Content does not match an image signature',\
@@ -237,7 +236,7 @@ SecMarker "END-REQUEST-914-FILE-UPLOAD-IMAGE"
 
 # Check for valid file contents in protected URI and block if there is no match, URI's are configured in 901180
 SecRule REQUEST_FILENAME "@rx ^.*$" \
-    "id:9142050,\
+    "id:914025,\
     phase:2,\
     pass,\
     log,\
@@ -262,7 +261,7 @@ SecRule REQUEST_FILENAME "@rx ^.*$" \
 # containing for example "image/png;base64,iVBORw0KGgoA......"
 # This rule assumes that the base64 encoded argument is called 'logo' and requires a minimum 12 byte long b64 string
 SecRule ARGS:logo "@rx ^image/(?:jpeg|jpg|gif|png|bmp|image|ico);base64,([a-zA-Z0-9\-_]{12})" \
-    "id:9142060,\
+    "id:914026,\
     phase:2,\
     pass,\
     capture,\
@@ -283,14 +282,14 @@ SecRule ARGS:logo "@rx ^image/(?:jpeg|jpg|gif|png|bmp|image|ico);base64,([a-zA-Z
         setvar:'tx.msg=%{rule.msg}',\
         ctl:ruleRemoveTargetById=941130;ARGS:logo"
 
-SecAction "id:9142070,phase:2,pass,nolog,noauditlog,skipAfter:END-REQUEST-914-FILE-UPLOAD-DOCUMENT"
+SecAction "id:914027,phase:2,pass,nolog,noauditlog,skipAfter:END-REQUEST-914-FILE-UPLOAD-DOCUMENT"
 
 SecMarker "BEGIN-REQUEST-914-FILE-UPLOAD-DOCUMENT"
 
 # Inspect long base64 encoded strings for images
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx ^(?:[a-zA-Z0-9\-_]{45})(?:[a-zA-Z0-9\-_]{3})*(?:[a-zA-Z0-9\-_]{1}==|[a-zA-Z0-9\-_]{2}=)?" \
-    "id:9142080,\
+    "id:914028,\
     phase:2,\
     pass,\
     noauditlog,\
@@ -311,7 +310,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
 # Inspect long base64 encoded strings for executables
 SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|REQUEST_BODY|REQUEST_HEADERS|XML:/*|XML://@* \
     "@rx ^(?:[a-zA-Z0-9\-_]{45})(?:[a-zA-Z0-9\-_]{3})*(?:[a-zA-Z0-9\-_]{1}==|[a-zA-Z0-9\-_]{2}=)?" \
-    "id:9142090,\
+    "id:914029,\
     phase:2,\
     pass,\
     log,\
@@ -340,7 +339,7 @@ SecRule ARGS|ARGS_NAMES|REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES
 
 # Check if for image files, and skip further checks
 SecRule FILES_TMP_CONTENT|REQUEST_BODY "@rx ^(?:\x89\x50\x4e\x47|\xff\xd8\xff(?:\xe1|\xe0|\xfe)|\x47\x49\x46\x38(?:\x37|\x39)\x61|\x42\x4d(?:\xf8\xa9|\x62\x25|\x76\x03)|\x00\x00\x01\x00|\x52\x49\x46\x46)" \
-    "id:9142100,\
+    "id:914100,\
     phase:2,\
     pass,\
     noauditlog,\
@@ -358,7 +357,7 @@ SecRule FILES_TMP_CONTENT|REQUEST_BODY "@rx ^(?:\x89\x50\x4e\x47|\xff\xd8\xff(?:
 
 # Check for office or pdf files, and skip further checks
 SecRule FILES_TMP_CONTENT|REQUEST_BODY "@rx ^(?:\x25\x50\x44\x46|\xd0\xcf\x11\xe0|\x4f\x46\x54\x32)" \
-    "id:9142110,\
+    "id:914110,\
     phase:2,\
     pass,\
     noauditlog,\
@@ -379,7 +378,7 @@ SecRule FILES_TMP_CONTENT|REQUEST_BODY "@rx ^(?:\x25\x50\x44\x46|\xd0\xcf\x11\xe
 # contains something different than what a regular upload would have in many cases so it will increase the anomaly
 # score with NOTICE score as something that may be interesting to verify
 SecAction \
-    "id:9142120,\
+    "id:914120,\
     phase:2,\
     pass,\
     log,\


### PR DESCRIPTION
CRS uses ID range 900000-999999 (6 digits). The ids used in this file were in the range of 9140000-9149999 (7 digits).